### PR TITLE
Add pod disruption budget

### DIFF
--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/helm/templates/pdb.yaml
+++ b/helm/templates/pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "blog.fullname" . }}
+  labels:
+    {{- include "blog.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: {{ include "blog.fullname" . }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -47,7 +47,7 @@ resources:
     memory: 128Mi
 
 autoscaling:
-  enabled: false
+  enabled: true
   minReplicas: 1
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
## Summary

- [x] Add Pod Disruption Budget with minimum of 1 pod available. In case I'm draining a worker node I want the workload to be up and running
- [x] Enable HPA to max 3 replicas